### PR TITLE
Fix path to pybiocfilecache exceptions

### DIFF
--- a/geniml/bbclient/bbclient.py
+++ b/geniml/bbclient/bbclient.py
@@ -11,7 +11,7 @@ import s3fs
 import zarr
 from botocore.exceptions import ClientError
 from pybiocfilecache import BiocFileCache
-from pybiocfilecache._exceptions import RnameExistsError
+from pybiocfilecache.exceptions import RnameExistsError
 from ubiquerg import is_url
 from zarr import Array
 from zarr.errors import PathNotFoundError


### PR DESCRIPTION
`_exceptions.py` became `exceptions.py`: https://github.com/BiocPy/pyBiocFileCache/commit/74f8adec6304f5a69695e3eb24020eadc2d4fda1